### PR TITLE
switch from indices to vector(compatibility)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,3 +26,7 @@ include_directories(
 
 add_executable(main src/main.cpp src/groundSeg.cpp include/groundSeg.h)
 target_link_libraries(main ${catkin_LIBRARIES})
+find_package(PCL REQUIRED)
+include_directories(${PCL_INCLUDE_DIRS})
+link_directories(${PCL_LIBRARY_DIRS})
+add_definitions(${PCL_DEFINITIONS})

--- a/include/groundSeg.h
+++ b/include/groundSeg.h
@@ -1,9 +1,7 @@
 #ifndef GROUNDSEG_H_
 #define GROUNDSEG_H_
 
-#include <pcl/filters/filter.h>
 #include <pcl/filters/filter_indices.h>
-
 
 #define delta 0.1f
 #define epsilon 0.3f
@@ -13,15 +11,15 @@
 
 namespace pcl
 {
-  class GroundSeg: public FilterIndices<pcl::PointXYZ>
+  class GroundSeg: public FilterIndices<PointXYZ>
   {
     protected:
-      using Filter<pcl::PointXYZ>::filter_name_;
-      using Filter<pcl::PointXYZ>::getClassName;
-      using Filter<pcl::PointXYZ>::input_;
-      using Filter<pcl::PointXYZ>::indices_;
+      using Filter<PointXYZ>::filter_name_;
+      using Filter<PointXYZ>::getClassName;
+      using Filter<PointXYZ>::input_;
+      using Filter<PointXYZ>::indices_;
 
-      using PointCloud = typename FilterIndices<pcl::PointXYZ>::PointCloud;
+      using PointCloud = typename FilterIndices<PointXYZ>::PointCloud;
 
     public:
       GroundSeg (const float resolution)
@@ -38,7 +36,7 @@ namespace pcl
       inline float getResolution () { return (resolution_); }
 
       void getGround(PointCloud &ground);
-      Indices nonGroundIndices;
+      std::vector<int> nonGroundIndices;
 
     protected:
       /** \brief The resolution. */
@@ -46,12 +44,12 @@ namespace pcl
 
       void applyFilter (PointCloud &output) override;
 
-      inline void applyFilter (Indices &indices) override
+      inline void applyFilter (std::vector<int> &indices) override
       {
         applyFilterIndices (indices);
       }
 
-      void applyFilterIndices (Indices &indices);
+      void applyFilterIndices (std::vector<int> &indices);
   };
 }
 #endif

--- a/src/groundSeg.cpp
+++ b/src/groundSeg.cpp
@@ -2,6 +2,7 @@
 #include <pcl/common/io.h>
 #include <pcl/common/point_tests.h>
 #include <pcl/filters/extract_indices.h>
+
 #include "../include/groundSeg.h" //VSCODE nao reconhece "groundSeg.h" - só para tirar squiggle do VSCODE
 
 #include <chrono>
@@ -45,7 +46,7 @@ void pcl::GroundSeg::applyFilter (PointCloud &output)
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-void pcl::GroundSeg::applyFilterIndices (Indices &indices)
+void pcl::GroundSeg::applyFilterIndices (std::vector<int> &indices)
 {
   auto start_division = high_resolution_clock::now();
 


### PR DESCRIPTION
pcl::Indices was generating errors with melodic so it was substituted to std::vector<int> 